### PR TITLE
Removing mongoDB default options from _id

### DIFF
--- a/lib/object-store.js
+++ b/lib/object-store.js
@@ -19,7 +19,7 @@ module.exports = class ObjectStore {
 		} catch (e) {
 			let schema = new mongoose.Schema(
 				{
-					_id: {type: String, index: true, required: true},
+					_id: String,
 					data: mongoose.Schema.Types.Mixed
 				}, {
 					validateBeforeSave: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monrule",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A simple cache to persist expensive function results",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
It is discouraged to set the index on the _id field as said by [Valeri Karpov](https://github.com/Automattic/mongoose/issues/5413#issuecomment-312966668).
This probably also holds true for the required option.